### PR TITLE
結果発表画面の修正

### DIFF
--- a/bingo.html
+++ b/bingo.html
@@ -52,7 +52,7 @@
                 <img id="silverImg" src="images/silver-axe.png" alt="銀の斧">
             </div>
         </div>
-        <button id="toSilverButton" class="small-button">銀の斧の景品選択へ</button>
+        <button id="toSilverButton" class="small-button">プレミアム景品選択へ</button>
     </div>
 
     <div id="silverPrizeScreen" class="screen">

--- a/bingo.html
+++ b/bingo.html
@@ -44,6 +44,14 @@
     <div id="resultScreen" class="screen">
         <h1 class="screen-title">結果発表</h1>
         <div id="resultMessage" class="result-text"></div>
+        <div class="result-container">
+            <div class="result">
+                <img id="goldImg" src="images/gold-axe.png" alt="金の斧">
+            </div>
+            <div class="result">
+                <img id="silverImg" src="images/silver-axe.png" alt="銀の斧">
+            </div>
+        </div>
         <button id="toSilverButton" class="small-button">銀の斧の景品選択へ</button>
     </div>
 
@@ -86,5 +94,6 @@
     <audio id="winSound" src="sounds/win.mp3"></audio>
 
     <script src="script.js"></script>
+    <script src="node_modules/canvas-confetti/dist/confetti.browser.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,15 @@
 {
   "name": "bingo-game-2024",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "bingo-game-2024",
+      "version": "1.0.0",
+      "license": "ISC",
       "devDependencies": {
+        "canvas-confetti": "^1.9.3",
         "electron": "^33.2.1",
         "electron-builder": "^25.1.8"
       }
@@ -1436,6 +1441,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "dev": true,
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
       }
     },
     "node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
       "icon": "assets/win/bingo.ico",
       "target": "nsis"
     },
-    "nsis" :{
+    "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
     }
   },
   "devDependencies": {
+    "canvas-confetti": "^1.9.3",
     "electron": "^33.2.1",
     "electron-builder": "^25.1.8"
   }

--- a/script.js
+++ b/script.js
@@ -151,12 +151,63 @@ document.getElementById('axeResultButton').addEventListener('click', () => {
     }
 })
 
+// 紙吹雪アニメーション共通パラメータ
+var confettiDefaultSettings = {
+    spread: 360,
+        ticks: 50,
+        gravity: 0,
+        decay: 0.94,
+        startVelocity: 30,
+};
+
+// 当たりが金の斧の時のパラメータ
+var goldSettings = {
+    colors: ['FFE400', 'FFBD00', 'E89400', 'FFCA6C', 'FDFFB8'],
+    origin: {
+        x: 0.27,
+        y: 0.55
+    }
+};
+
+// 当たりが銀の斧の時のパラメータ
+var silverSettings = {
+    colors: ['BDC3C9', 'E9EAEA', '979C9A', 'EEEEEE', '9EACB4'],
+    origin: {
+        x: 0.73,
+        y: 0.55
+    }
+};
+
+// 結果発表画面 紙吹雪アニメーション(canvas-confetti)
+function starShoot(colorSettings){
+    confetti({
+        ...confettiDefaultSettings,
+        ...colorSettings,
+        particleCount: 50,
+        scalar: 1.2,
+        shapes: ['star']
+    });
+
+    confetti({
+        ...confettiDefaultSettings,
+        ...colorSettings,
+        particleCount: 50,
+        scalar: 0.75,
+        shapes: ['circle']
+    });
+};
+
 // 斧選択結果の表示
 function showAxeResult() {
+const goldImg = document.getElementById('goldImg');
+const silverImg = document.getElementById('silverImg');
+
+    const resultFlag = Math.random();
+
     showScreen('resultScreen');
     const resultMessage = document.getElementById('resultMessage');
 
-    const message = Math.random() > 0.5 ?
+    const message = resultFlag > 0.5 ?
         '当たりは銀の斧!' :
         '当たりは金の斧!';
 
@@ -174,6 +225,22 @@ function showAxeResult() {
             }, 1000);
         }
     }, 50);
+
+    if(resultFlag > 0.5){
+        goldImg.setAttribute('class', 'dark');
+        silverImg.setAttribute('class', 'brite');
+        setTimeout(starShoot(silverSettings), 0);
+        setTimeout(starShoot(silverSettings), 200);
+        setTimeout(starShoot(silverSettings), 400);
+        setTimeout(starShoot(silverSettings), 600);
+    }else{
+        goldImg.setAttribute('class', 'brite');
+        silverImg.setAttribute('class', 'dark');
+        setTimeout(starShoot(goldSettings), 0);
+        setTimeout(starShoot(goldSettings), 200);
+        setTimeout(starShoot(goldSettings), 400);
+        setTimeout(starShoot(goldSettings), 600);
+    };
 }
 
 /**

--- a/styles.css
+++ b/styles.css
@@ -159,6 +159,47 @@ body, html {
     transform: scale(1.1);
 }
 
+/* 結果発表エリア */
+.result-container {
+    align-items: center;
+    display: flex;
+    justify-content: space-around;
+    margin: 40px 0;
+    width: 100%;
+}
+
+.result {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    cursor: pointer;
+    height: 30vh;
+    padding: 20px;
+    position: relative;
+    transition: all 0.3s;
+    width: 30vh;
+}
+
+.result img {
+    height: 100%;
+    object-fit: contain;
+    width: 100%;
+}
+
+/* 明度調整 */
+#goldImg.brite {
+    filter: brightness(1.4);
+}
+#goldImg.dark {
+    filter: brightness(0.6);
+}
+
+#silverImg.brite {
+    filter: brightness(1.4);
+}
+#silverImg.dark {
+    filter: brightness(0.6);
+}
+  
 /* ガイドテキスト */
 .guide-text {
     animation: pulse 1s infinite;

--- a/styles.css
+++ b/styles.css
@@ -187,14 +187,14 @@ body, html {
 
 /* 明度調整 */
 #goldImg.brite {
-    filter: brightness(1.4);
+    filter: brightness(1.1);
 }
 #goldImg.dark {
     filter: brightness(0.6);
 }
 
 #silverImg.brite {
-    filter: brightness(1.4);
+    filter: brightness(1.1);
 }
 #silverImg.dark {
     filter: brightness(0.6);


### PR DESCRIPTION
結果発表ボタン押下後に遷移する画面
主な仕様は以下の通り
- 当たりの斧の画像は明度を上げ、星が飛び散るアニメーションを付与
- 外れの斧は明度を下げる
- アニメーションは```Canvas Confetti```ライブラリを使用(```package-lock.json```が入っていれば```npm ci```でインストールできるはずです。)

![スクリーンショット 2025-01-01 174520](https://github.com/user-attachments/assets/eb1e5dc5-9ede-4196-93da-edd9d92ae7f0)

ご意見あれば是非とも...

それから、この画面の次の遷移先はどうしますか？当たりの商品リストに遷移で良い？(遷移先の画面によって遷移ボタンのテキストが変わると思うので一応確認)
遷移先画面の仕様確認後にボタンテキストは修正します。