### PR TITLE
斧選択画面のデザイン修正

### DIFF
--- a/bingo.html
+++ b/bingo.html
@@ -64,10 +64,10 @@
     <div id="axeSelectionScreen" class="screen">
         <h1 class="screen-title">Which choose?</h1>
         <div class="axe-container">
-            <div class="axe" data-axe="gold">
+            <div class="axe gold" data-axe="gold">
                 <img src="images/gold-axe.png" alt="金の斧">
             </div>
-            <div class="axe" data-axe="silver">
+            <div class="axe silver" data-axe="silver">
                 <img src="images/silver-axe.png" alt="銀の斧">
             </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -318,28 +318,32 @@ label.toggle:has(input[type="checkbox"]){
     justify-content: space-around;
     margin: 40px 0;
     width: 100%;
+    gap: 60px;
 }
 
 .axe {
     background: rgba(255, 255, 255, 0.1);
     border-radius: 20px;
     cursor: pointer;
-    height: 30vh;
+    height: 40vh;
     padding: 20px;
     position: relative;
     transition: all 0.3s;
-    width: 30vh;
+    width: 40vh;
+}
+
+.axe.gold {
+    border: 5px solid #FDB931 ;
+}
+
+.axe.silver {
+    border: 5px solid #E8E8E8 ;
 }
 
 .axe img {
     height: 100%;
     object-fit: contain;
     width: 100%;
-}
-
-.axe:hover {
-    box-shadow: 0 0 30px rgba(255, 215, 0, 0.5);
-    transform: scale(1.1);
 }
 
 /* 結果発表アニメーションエリア */


### PR DESCRIPTION
- 金色・銀色の枠線を付けました
- 斧アイコンのコンテナのサイズを拡大しました
- ホバー時のスタイル指定を使わなくなったためオミットしました

![スクリーンショット 2025-01-16 233556](https://github.com/user-attachments/assets/ef57fd0d-250b-4b2a-a6e1-ab33c4d6342d)
